### PR TITLE
Fix layout so PaintControl can better stretch across bounds

### DIFF
--- a/src/Avalonia.Samples/Drawing/RectPainter/MainWindow.axaml
+++ b/src/Avalonia.Samples/Drawing/RectPainter/MainWindow.axaml
@@ -2,24 +2,28 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-				xmlns:controls="using:RectPainter.Controls"
-				xmlns:vm="using:RectPainter.ViewModels"
+        xmlns:controls="using:RectPainter.Controls"
+        xmlns:vm="using:RectPainter.ViewModels"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="RectPainter.MainWindow"
         Title="Rect Painter Sample - Drag out rectangles with the mouse. Use Shift/Ctrl/Alt to change color"
-				Icon="/Assets/avalonia-logo.ico">
-		<Design.DataContext>
-				<vm:MainWindowViewModel/>
-		</Design.DataContext>
+        Icon="/Assets/avalonia-logo.ico">
+    <Design.DataContext>
+        <vm:MainWindowViewModel/>
+    </Design.DataContext>
 		
-		<DockPanel>
-				<StackPanel Orientation="Horizontal" DockPanel.Dock="Bottom">
-						<TextBlock Width="50" Text="Cursor:"/>
-						<TextBlock Width="120" Text="{Binding MousePosition}"/>
-						<TextBlock Width="70" Text="Rectangle:"/>
-						<TextBlock Width="100" Text="{Binding Rect}"/>
-				</StackPanel>
-				<TextBlock Text="Use mouse with Shift/Alt/Ctrl key modifiers pressed."/>
-				<controls:PaintControl DataContext="{Binding Vm}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
-		</DockPanel>
+    <Grid RowDefinitions="auto, *, auto">
+        <TextBlock Grid.Row="0" Text="Use mouse with Shift/Alt/Ctrl key modifiers pressed."/>
+
+        <Grid Grid.Row="1">
+            <controls:PaintControl DataContext="{Binding Vm}" />
+        </Grid>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal">
+            <TextBlock Width="50" Text="Cursor:"/>
+            <TextBlock Width="120" Text="{Binding MousePosition}"/>
+            <TextBlock Width="70" Text="Rectangle:"/>
+            <TextBlock Width="100" Text="{Binding Rect}"/>
+        </StackPanel>
+    </Grid>
 </Window>


### PR DESCRIPTION
## What does the pull request do?
The `PaintControl` now paints across the entire window (besides the top and bottom areas with `TextBlock`s).

**Scope of this PR:**
Change `DockPanel` to `Grid`.

I could not get the original approach to correctly work as there was always an extra `TextBlock` height of gap of undrawable area at the top.

## What is the current behavior?
Left side of window doesn't allow painting, so it was broken at some point.
