### PR TITLE
Fix syntax highlighting

### DIFF
--- a/src/Avalonia.Samples/CompleteApps/SimpleToDoList/README.adoc
+++ b/src/Avalonia.Samples/CompleteApps/SimpleToDoList/README.adoc
@@ -653,7 +653,7 @@ In the event itself we cancel the event as long as `_canClose` is not set to tru
 
 NOTE: It is highly recommended to run I/O-operations https://learn.microsoft.com/en-us/dotnet/standard/io/asynchronous-file-i-o[[`async`\]].
 
-[source]
+[source,c#]
 .App.axaml.cs
 ----
 // We want to save our ToDoList before we actually shutdown the App. As File I/O is async, we need to wait until file is closed


### PR DESCRIPTION
Missing syntax highlighting for c# code

## What does the pull request do?
Minor change : update syntaxt highlighting in a doc

**Scope of this PR:**
- [X] fix or update to an existing sample
- [ ] add a new sample

## What is the current behavior?
C# Syntax is not highlighted


## Checklist
<!-- Please fill out the checklist below.  -->

**If this is a new Sample**
- [ ] Added a ReadMe-file
- [ ] Updated the landing page
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with a link to your sample in the related documentation page

**In any case**
- [X] Spell-checking done
- [X] Checked if all hyperlinks work
- [X] Checked if all images are visible

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
