### PR TITLE
fix(IDataTemplateSample): rename _SelectedShape to _selectedShape 

### DIFF
--- a/src/Avalonia.Samples/DataTemplates/IDataTemplateSample/README.adoc
+++ b/src/Avalonia.Samples/DataTemplates/IDataTemplateSample/README.adoc
@@ -85,15 +85,15 @@ In the file `ViewModels ► MainWindowViewModel.cs` we will add a Property `Sele
 public class MainWindowViewModel : ViewModelBase
 {
 
-    private ShapeType _SelectedShape;
+    private ShapeType _selectedShape;
 
     /// <summary>
     /// Gets or sets the selected ShapeType
     /// </summary>
     public ShapeType SelectedShape
     {
-        get { return _SelectedShape; }
-        set { this.RaiseAndSetIfChanged(ref _SelectedShape, value); }
+        get { return _selectedShape; }
+        set { this.RaiseAndSetIfChanged(ref _selectedShape, value); }
     }
 
     /// <summary>

--- a/src/Avalonia.Samples/DataTemplates/IDataTemplateSample/ViewModels/MainWindowViewModel.cs
+++ b/src/Avalonia.Samples/DataTemplates/IDataTemplateSample/ViewModels/MainWindowViewModel.cs
@@ -7,15 +7,15 @@ namespace IDataTemplateSample.ViewModels
     public class MainWindowViewModel : ViewModelBase
     {
 
-        private ShapeType _SelectedShape;
+        private ShapeType _selectedShape;
 
         /// <summary>
         /// Gets or sets the selected ShapeType
         /// </summary>
         public ShapeType SelectedShape
         {
-            get { return _SelectedShape; }
-            set { this.RaiseAndSetIfChanged(ref _SelectedShape, value); }
+            get { return _selectedShape; }
+            set { this.RaiseAndSetIfChanged(ref _selectedShape, value); }
         }
 
         /// <summary>


### PR DESCRIPTION
Small fix to follow .NET naming conventions – private field renamed to _camelCase.

Related to #141. 
     